### PR TITLE
Stop updating the "Correct Me" role emoji on name edit.

### DIFF
--- a/WordOfTheDay/Program.cs
+++ b/WordOfTheDay/Program.cs
@@ -184,12 +184,6 @@ namespace WordOfTheDay
 		#endregion
 
 		#region events
-		private Task Client_GuildMemberUpdated(DiscordClient sender, GuildMemberUpdateEventArgs e)
-		{
-			CheckPencil(e.Member);
-			return Task.CompletedTask;
-		}
-
 		private async Task<Task> Client_MessageCreated(DiscordClient sender, MessageCreateEventArgs e)
 		{
 			if (e.Author.IsBot || e.Author.IsCurrent) return Task.CompletedTask;

--- a/WordOfTheDay/Program.cs
+++ b/WordOfTheDay/Program.cs
@@ -72,7 +72,6 @@ namespace WordOfTheDay
 			this.Client.GuildAvailable += Client_GuildAvailable;
 			this.Client.ClientErrored += Client_ClientError;
 			this.Client.MessageCreated += Client_MessageCreated;
-			this.Client.GuildMemberUpdated += Client_GuildMemberUpdated;
 			this.Client.MessageReactionAdded += Client_MessageReactionAdded;
 			this.Client.MessageReactionRemoved += Client_MessageReactionRemoved;
 			this.Client.GuildMemberAdded += Client_GuildMemberAdded;


### PR DESCRIPTION
This change allows users to add the emoji to their own names.